### PR TITLE
Un-escape username and password

### DIFF
--- a/RtspClientSharp/ConnectionParameters.cs
+++ b/RtspClientSharp/ConnectionParameters.cs
@@ -82,8 +82,8 @@ namespace RtspClientSharp
 
                 if (tokens.Length == 2)
                 {
-                    login = tokens[0];
-                    password = tokens[1];
+                    login = Uri.UnescapeDataString(tokens[0]);
+                    password = Uri.UnescapeDataString(tokens[1]);
                 }
             }
 


### PR DESCRIPTION
Un-escape username and password because of they may contain special characters escaped.