### PR TITLE
 Multicast, improvements, bug fixes

### DIFF
--- a/RtspClientSharp.UnitTests/Rtsp/RtspTransportClientEmulator.cs
+++ b/RtspClientSharp.UnitTests/Rtsp/RtspTransportClientEmulator.cs
@@ -57,6 +57,8 @@ namespace RtspClientSharp.UnitTests.Rtsp
 
         public EndPoint RemoteEndPoint => new IPEndPoint(IPAddress.Loopback, 11080);
 
+        public EndPoint LocalEndPoint => new IPEndPoint(IPAddress.Loopback, 11080);
+
         public virtual Task ConnectAsync(CancellationToken token)
         {
             return Task.CompletedTask;

--- a/RtspClientSharp.UnitTests/Rtsp/RtspTransportClientTests.cs
+++ b/RtspClientSharp.UnitTests/Rtsp/RtspTransportClientTests.cs
@@ -19,6 +19,7 @@ namespace RtspClientSharp.UnitTests.Rtsp
             private MemoryStream _responseStream;
 
             public override EndPoint RemoteEndPoint => new IPEndPoint(0, 0);
+            public override EndPoint LocalEndPoint => new IPEndPoint(0, 0);
 
             public RtspTransportClientFake(ConnectionParameters connectionParameters,
                 Func<string, string> responseProvider)

--- a/RtspClientSharp/Rtcp/RtcpByePacket.cs
+++ b/RtspClientSharp/Rtcp/RtcpByePacket.cs
@@ -1,14 +1,30 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
+using RtspClientSharp.Rtsp;
 using RtspClientSharp.Utils;
 
 namespace RtspClientSharp.Rtcp
 {
-    class RtcpByePacket : RtcpPacket
+    class RtcpByePacket : RtcpPacket, ISerializablePacket
     {
         private readonly List<uint> _syncSourcesIds = new List<uint>();
 
         public IEnumerable<uint> SyncSourcesIds => _syncSourcesIds;
+
+        public RtcpByePacket()
+        {
+            PaddingFlag = false;
+            PayloadType = 203;
+        }
+
+        public RtcpByePacket(uint syncSourceId): this()
+        {
+            _syncSourcesIds.Add(syncSourceId);
+            SourceCount = 1;
+            DwordLength = 1;
+            Length = (DwordLength + 1) * 4;
+        }
 
         protected override void FillFromByteSegment(ArraySegment<byte> byteSegment)
         {
@@ -22,6 +38,21 @@ namespace RtspClientSharp.Rtcp
 
                 _syncSourcesIds.Add(ssrc);
             }
+        }
+
+        public new void Serialize(Stream stream)
+        {
+            base.Serialize(stream);
+
+            if (_syncSourcesIds.Count > 0)
+            {
+                stream.WriteByte((byte)(_syncSourcesIds[0] >> 24));
+                stream.WriteByte((byte)(_syncSourcesIds[0] >> 16));
+                stream.WriteByte((byte)(_syncSourcesIds[0] >> 8));
+                stream.WriteByte((byte)_syncSourcesIds[0]);
+            }
+            else
+                throw new RtspClientException("Can't make RTCP packet without Identifier");
         }
     }
 }

--- a/RtspClientSharp/Rtcp/RtcpReceiverReportsProvider.cs
+++ b/RtspClientSharp/Rtcp/RtcpReceiverReportsProvider.cs
@@ -23,7 +23,7 @@ namespace RtspClientSharp.Rtcp
             _machineName = Environment.MachineName;
         }
 
-        public IEnumerable<RtcpPacket> GetReportPackets()
+        public IEnumerable<RtcpPacket> GetReportSdesPackets()
         {
             RtcpReceiverReportPacket receiverReport = CreateReceiverReport();
 
@@ -32,6 +32,17 @@ namespace RtspClientSharp.Rtcp
             RtcpSdesReportPacket sdesReport = CreateSdesReport();
 
             yield return sdesReport;
+        }
+
+        public IEnumerable<RtcpPacket> GetReportByePackets()
+        {
+            RtcpReceiverReportPacket receiverReport = CreateReceiverReport();
+
+            yield return receiverReport;
+
+            RtcpByePacket byeReport = new RtcpByePacket(_senderSyncSourceId);
+
+            yield return byeReport;
         }
 
         private RtcpReceiverReportPacket CreateReceiverReport()

--- a/RtspClientSharp/Rtcp/RtcpSdesNameItem.cs
+++ b/RtspClientSharp/Rtcp/RtcpSdesNameItem.cs
@@ -21,7 +21,7 @@ namespace RtspClientSharp.Rtcp
             byte[] domainNameBytes = Encoding.ASCII.GetBytes(DomainName);
 
             stream.WriteByte(1);
-            stream.WriteByte((byte) (domainByteLength + 1));
+            stream.WriteByte((byte) domainByteLength);
             stream.Write(domainNameBytes, 0, domainByteLength);
             stream.WriteByte(0);
         }

--- a/RtspClientSharp/Rtcp/RtcpSdesReportPacket.cs
+++ b/RtspClientSharp/Rtcp/RtcpSdesReportPacket.cs
@@ -42,7 +42,7 @@ namespace RtspClientSharp.Rtcp
                 chunk.Serialize(stream);
             }
 
-            if (_paddingByteCount > 0)
+            if ((_paddingByteCount > 0) && (_paddingByteCount < 4))
                 stream.Write(PaddingBytes, 0, _paddingByteCount);
         }
     }

--- a/RtspClientSharp/Rtcp/RtcpSdesReportPacket.cs
+++ b/RtspClientSharp/Rtcp/RtcpSdesReportPacket.cs
@@ -18,18 +18,11 @@ namespace RtspClientSharp.Rtcp
 
             SourceCount = chunks.Count;
             PayloadType = 202;
+            PaddingFlag = false;  // this is different padding, see https://www.ietf.org/rfc/rfc3550.txt page 46
 
             int length = chunks.Sum(chunk => chunk.SerializedLength);
 
-            int fraction = length % 4;
-
-            if (fraction == 0)
-                PaddingFlag = false;
-            else
-            {
-                PaddingFlag = true;
-                _paddingByteCount = 4 - fraction;
-            }
+            _paddingByteCount = 4 - length % 4;
 
             DwordLength = (length + 3) / 4;
             Length = (DwordLength + 1) * 4;
@@ -49,7 +42,7 @@ namespace RtspClientSharp.Rtcp
                 chunk.Serialize(stream);
             }
 
-            if (PaddingFlag)
+            if (_paddingByteCount > 0)
                 stream.Write(PaddingBytes, 0, _paddingByteCount);
         }
     }

--- a/RtspClientSharp/RtpTransportProtocol.cs
+++ b/RtspClientSharp/RtpTransportProtocol.cs
@@ -3,6 +3,7 @@
     public enum RtpTransportProtocol
     {
         TCP,
-        UDP
+        UDP,
+        MULTICAST
     }
 }

--- a/RtspClientSharp/Rtsp/IRtspTransportClient.cs
+++ b/RtspClientSharp/Rtsp/IRtspTransportClient.cs
@@ -9,6 +9,7 @@ namespace RtspClientSharp.Rtsp
     internal interface IRtspTransportClient : IDisposable
     {
         EndPoint RemoteEndPoint { get; }
+        EndPoint LocalEndPoint { get; }
 
         Task ConnectAsync(CancellationToken token);
 

--- a/RtspClientSharp/Rtsp/RtspClientInternal.cs
+++ b/RtspClientSharp/Rtsp/RtspClientInternal.cs
@@ -344,8 +344,8 @@ namespace RtspClientSharp.Rtsp
                         IPEndPoint endPointRtcp = new IPEndPoint(localIpToServer, rtcpChannelNumber);
 
                         rtcpClient.Bind(endPointRtcp);
-                        rtcpClient.JoinMulticastSourceGroup(destinationAddress, localIpToServer, sourceAddress);
-                        _udpJoinedGroupsMap[rtcpClient] = new IPEndPoint(destinationAddress, rtcpChannelNumber);
+                        IPAddress whereToReportRtcp = rtcpClient.JoinMulticastSourceGroup(destinationAddress, localIpToServer, sourceAddress);
+                        _udpJoinedGroupsMap[rtcpClient] = new IPEndPoint(whereToReportRtcp, rtcpChannelNumber);
                     }
                     catch
                     {
@@ -361,8 +361,8 @@ namespace RtspClientSharp.Rtsp
 
                 var udpHolePunchingPacketSegment = new ArraySegment<byte>(Array.Empty<byte>());
 
+                // send "punch" packet to multicast group
                 await rtpClient.SendToAsync(udpHolePunchingPacketSegment, SocketFlags.None, _udpJoinedGroupsMap[rtpClient]);
-                await rtcpClient.SendToAsync(udpHolePunchingPacketSegment, SocketFlags.None, _udpJoinedGroupsMap[rtcpClient]);
 
                 _udpClientsMap[rtpChannelNumber] = rtpClient;
                 _udpClientsMap[rtcpChannelNumber] = rtcpClient;

--- a/RtspClientSharp/Rtsp/RtspClientInternal.cs
+++ b/RtspClientSharp/Rtsp/RtspClientInternal.cs
@@ -31,6 +31,8 @@ namespace RtspClientSharp.Rtsp
 
         private readonly Dictionary<int, ITransportStream> _streamsMap = new Dictionary<int, ITransportStream>();
         private readonly ConcurrentDictionary<int, Socket> _udpClientsMap = new ConcurrentDictionary<int, Socket>();
+        private readonly ConcurrentDictionary<int, int> _udpRtp2RtcpMap = new ConcurrentDictionary<int, int>();
+        private readonly ConcurrentDictionary<Socket, IPEndPoint> _udpJoinedGroupsMap = new ConcurrentDictionary<Socket, IPEndPoint>();
 
         private readonly Dictionary<int, RtcpReceiverReportsProvider> _reportProvidersMap =
             new Dictionary<int, RtcpReceiverReportsProvider>();
@@ -195,12 +197,16 @@ namespace RtspClientSharp.Rtsp
 
                 try
                 {
-                    IPEndPoint endPoint = new IPEndPoint(IPAddress.Any, 0);
+                    IPAddress localIpToServer = IPAddress.Any;
+                    if (_rtspTransportClient.LocalEndPoint is IPEndPoint localIpEndPoint)
+                        localIpToServer = localIpEndPoint.Address;
+
+                    IPEndPoint endPoint = new IPEndPoint(localIpToServer, 0);
                     rtpClient.Bind(endPoint);
 
                     int rtpPort = ((IPEndPoint)rtpClient.LocalEndPoint).Port;
 
-                    endPoint = new IPEndPoint(IPAddress.Any, rtpPort + 1);
+                    endPoint = new IPEndPoint(localIpToServer, rtpPort + 1);
 
                     try
                     {
@@ -208,7 +214,7 @@ namespace RtspClientSharp.Rtsp
                     }
                     catch (SocketException e) when (e.SocketErrorCode == SocketError.AddressAlreadyInUse)
                     {
-                        endPoint = new IPEndPoint(IPAddress.Any, 0);
+                        endPoint = new IPEndPoint(localIpToServer, 0);
                         rtcpClient.Bind(endPoint);
                     }
 
@@ -224,6 +230,14 @@ namespace RtspClientSharp.Rtsp
                     rtcpClient.Close();
                     throw;
                 }
+            }
+            else if (_connectionParameters.RtpTransport == RtpTransportProtocol.MULTICAST)
+            {
+                rtpClient = NetworkClientFactory.CreateUdpClient();
+                rtcpClient = NetworkClientFactory.CreateUdpClient();
+
+                setupRequest = _requestMessageFactory.CreateSetupUdpMulticastRequest(track.TrackName);
+                setupResponse = await _rtspTransportClient.EnsureExecuteRequest(setupRequest, token);
             }
             else
             {
@@ -241,9 +255,19 @@ namespace RtspClientSharp.Rtsp
             if (string.IsNullOrEmpty(transportHeader))
                 throw new RtspBadResponseException("Transport header is not found");
 
-            string portsAttributeName = _connectionParameters.RtpTransport == RtpTransportProtocol.UDP
-                ? "server_port"
-                : "interleaved";
+            string portsAttributeName;
+            switch (_connectionParameters.RtpTransport)
+            {
+                case RtpTransportProtocol.UDP:
+                    portsAttributeName = "server_port";
+                    break;
+                case RtpTransportProtocol.MULTICAST:
+                    portsAttributeName = "port";
+                    break;
+                default:
+                    portsAttributeName = "interleaved";
+                    break;
+            }
 
             string[] transportAttributes = transportHeader.Split(TransportAttributesSeparator, StringSplitOptions.RemoveEmptyEntries);
 
@@ -276,6 +300,73 @@ namespace RtspClientSharp.Rtsp
 
                 _udpClientsMap[rtpChannelNumber] = rtpClient;
                 _udpClientsMap[rtcpChannelNumber] = rtcpClient;
+                _udpRtp2RtcpMap[rtpChannelNumber] = rtcpChannelNumber;
+            }
+            else if (_connectionParameters.RtpTransport == RtpTransportProtocol.MULTICAST)
+            {
+                int equalSignIndex;
+                string destinationAttribute = transportAttributes.FirstOrDefault(a => a.StartsWith("destination", StringComparison.InvariantCultureIgnoreCase));
+
+                IPAddress destinationAddress;
+
+                if (destinationAttribute != null && (equalSignIndex = destinationAttribute.IndexOf("=", StringComparison.CurrentCultureIgnoreCase)) != -1)
+                    destinationAddress = IPAddress.Parse(destinationAttribute.Substring(++equalSignIndex).Trim());
+                else
+                    throw new RtspBadResponseException("Destination multicast IP is not found");
+
+                string sourceAttribute = transportAttributes.FirstOrDefault(a => a.StartsWith("source", StringComparison.InvariantCultureIgnoreCase));
+
+                IPAddress sourceAddress;
+
+                if (sourceAttribute != null && (equalSignIndex = sourceAttribute.IndexOf("=", StringComparison.CurrentCultureIgnoreCase)) != -1)
+                    sourceAddress = IPAddress.Parse(sourceAttribute.Substring(++equalSignIndex).Trim());
+                else
+                    sourceAddress = ((IPEndPoint)_rtspTransportClient.RemoteEndPoint).Address;
+
+                Debug.Assert(rtpClient != null, nameof(rtpClient) + " != null");
+                Debug.Assert(rtcpClient != null, nameof(rtcpClient) + " != null");
+
+                try
+                {
+                    // if we are conected to several networks, take local IP from already existing TCP connection
+                    IPAddress localIpToServer = IPAddress.Any;
+                    if (_rtspTransportClient.LocalEndPoint is IPEndPoint localIpEndPoint)
+                        localIpToServer = localIpEndPoint.Address;
+
+                    IPEndPoint endPointRtp = new IPEndPoint(localIpToServer, rtpChannelNumber);
+
+                    rtpClient.Bind(endPointRtp);
+                    rtpClient.JoinMulticastSourceGroup(destinationAddress, localIpToServer, sourceAddress);
+                    _udpJoinedGroupsMap[rtpClient] = new IPEndPoint(destinationAddress, rtpChannelNumber);
+
+                    try
+                    {
+                        IPEndPoint endPointRtcp = new IPEndPoint(localIpToServer, rtcpChannelNumber);
+
+                        rtcpClient.Bind(endPointRtcp);
+                        rtcpClient.JoinMulticastSourceGroup(destinationAddress, localIpToServer, sourceAddress);
+                        _udpJoinedGroupsMap[rtcpClient] = new IPEndPoint(destinationAddress, rtcpChannelNumber);
+                    }
+                    catch
+                    {
+                        rtcpClient.Close();
+                        throw;
+                    }
+                }
+                catch
+                {
+                    rtpClient.Close();
+                    throw;
+                }
+
+                var udpHolePunchingPacketSegment = new ArraySegment<byte>(Array.Empty<byte>());
+
+                await rtpClient.SendToAsync(udpHolePunchingPacketSegment, SocketFlags.None, _udpJoinedGroupsMap[rtpClient]);
+                await rtcpClient.SendToAsync(udpHolePunchingPacketSegment, SocketFlags.None, _udpJoinedGroupsMap[rtcpClient]);
+
+                _udpClientsMap[rtpChannelNumber] = rtpClient;
+                _udpClientsMap[rtcpChannelNumber] = rtcpClient;
+                _udpRtp2RtcpMap[rtpChannelNumber] = rtcpChannelNumber;
             }
 
             ParseSessionHeader(setupResponse.Headers[WellKnownHeaders.Session]);
@@ -324,6 +415,11 @@ namespace RtspClientSharp.Rtsp
 
             if (_connectionParameters.RtpTransport == RtpTransportProtocol.TCP)
                 await _rtspTransportClient.SendRequestAsync(teardownRequest, token);
+            else if (_connectionParameters.RtpTransport == RtpTransportProtocol.MULTICAST)
+            {
+                // There is no need to leave multicast group because it is done automatically by OS when socket closes
+                await _rtspTransportClient.EnsureExecuteRequest(teardownRequest, token);
+            }
             else
                 await _rtspTransportClient.EnsureExecuteRequest(teardownRequest, token);
         }
@@ -495,7 +591,7 @@ namespace RtspClientSharp.Rtsp
 
             while (!token.IsCancellationRequested)
             {
-                TpktPayload payload = await _tpktStream.ReadAsync();
+                TpktPayload payload = await _tpktStream.ReadAsync().WithCancellation(token); 
 
                 if (_streamsMap.TryGetValue(payload.Channel, out ITransportStream stream))
                     stream.Process(payload.PayloadSegment);
@@ -510,7 +606,7 @@ namespace RtspClientSharp.Rtsp
 
                 foreach (KeyValuePair<int, RtcpReceiverReportsProvider> pair in _reportProvidersMap)
                 {
-                    IEnumerable<RtcpPacket> packets = pair.Value.GetReportPackets();
+                    IEnumerable<RtcpPacket> packets = pair.Value.GetReportSdesPackets();
                     ArraySegment<byte> byteSegment = SerializeRtcpPackets(packets, bufferStream);
                     int rtcpChannel = pair.Key + 1;
 
@@ -534,8 +630,10 @@ namespace RtspClientSharp.Rtsp
 
                 if (transportStream is RtpStream rtpStream)
                 {
+                    if (!_udpClientsMap.TryGetValue(_udpRtp2RtcpMap[channelNumber], out Socket clientRtcp))
+                        throw new RtspClientException("RTP connection without RTCP");
                     RtcpReceiverReportsProvider receiverReportsProvider = _reportProvidersMap[channelNumber];
-                    receiveTask = ReceiveRtpFromUdpAsync(client, rtpStream, receiverReportsProvider, token);
+                    receiveTask = ReceiveRtpFromUdpAsync(client, clientRtcp, rtpStream, receiverReportsProvider, token);
                 }
                 else
                     receiveTask = ReceiveRtcpFromUdpAsync(client, transportStream, token);
@@ -546,7 +644,7 @@ namespace RtspClientSharp.Rtsp
             return Task.WhenAll(waitList);
         }
 
-        private async Task ReceiveRtpFromUdpAsync(Socket client, RtpStream rtpStream,
+        private async Task ReceiveRtpFromUdpAsync(Socket client, Socket clientRtcp, RtpStream rtpStream,
             RtcpReceiverReportsProvider reportsProvider,
             CancellationToken token)
         {
@@ -557,25 +655,46 @@ namespace RtspClientSharp.Rtsp
             int lastTimeRtcpReportsSent = Environment.TickCount;
             var bufferStream = new MemoryStream();
 
-            while (!token.IsCancellationRequested)
+            IEnumerable<RtcpPacket> packets;
+            ArraySegment<byte> byteSegment;
+
+            try
             {
-                int read = await client.ReceiveAsync(bufferSegment, SocketFlags.None);
+                while (!token.IsCancellationRequested)
+                {
+                    int read = await client.ReceiveAsync(bufferSegment, SocketFlags.None).WithCancellation(token);
 
-                var payloadSegment = new ArraySegment<byte>(readBuffer, 0, read);
-                rtpStream.Process(payloadSegment);
+                    var payloadSegment = new ArraySegment<byte>(readBuffer, 0, read);
+                    rtpStream.Process(payloadSegment);
 
-                int ticksNow = Environment.TickCount;
-                if (!TimeUtils.IsTimeOver(ticksNow, lastTimeRtcpReportsSent, nextRtcpReportInterval))
-                    continue;
+                    int ticksNow = Environment.TickCount;
+                    if (!TimeUtils.IsTimeOver(ticksNow, lastTimeRtcpReportsSent, nextRtcpReportInterval))
+                        continue;
 
-                lastTimeRtcpReportsSent = ticksNow;
-                nextRtcpReportInterval = GetNextRtcpReportIntervalMs();
+                    lastTimeRtcpReportsSent = ticksNow;
+                    nextRtcpReportInterval = GetNextRtcpReportIntervalMs();
 
-                IEnumerable<RtcpPacket> packets = reportsProvider.GetReportPackets();
-                ArraySegment<byte> byteSegment = SerializeRtcpPackets(packets, bufferStream);
+                    packets = reportsProvider.GetReportSdesPackets();
+                    byteSegment = SerializeRtcpPackets(packets, bufferStream);
 
-                await client.SendAsync(byteSegment, SocketFlags.None);
+                    if (_connectionParameters.RtpTransport == RtpTransportProtocol.UDP)
+                        await clientRtcp.SendAsync(byteSegment, SocketFlags.None).WithCancellation(token);
+                    else if (_connectionParameters.RtpTransport == RtpTransportProtocol.MULTICAST)
+                        await clientRtcp.SendToAsync(byteSegment, SocketFlags.None, _udpJoinedGroupsMap[clientRtcp]).WithCancellation(token);
+                }
             }
+            catch (OperationCanceledException)
+            {
+                if (!token.IsCancellationRequested) throw;
+            }
+
+            packets = reportsProvider.GetReportByePackets();
+            byteSegment = SerializeRtcpPackets(packets, bufferStream);
+
+            if (_connectionParameters.RtpTransport == RtpTransportProtocol.UDP)
+                await clientRtcp.SendAsync(byteSegment, SocketFlags.None);
+            else if (_connectionParameters.RtpTransport == RtpTransportProtocol.MULTICAST)
+                await clientRtcp.SendToAsync(byteSegment, SocketFlags.None, _udpJoinedGroupsMap[clientRtcp]);
         }
 
         private static async Task ReceiveRtcpFromUdpAsync(Socket client, ITransportStream stream,
@@ -584,12 +703,19 @@ namespace RtspClientSharp.Rtsp
             var readBuffer = new byte[Constants.UdpReceiveBufferSize];
             var bufferSegment = new ArraySegment<byte>(readBuffer);
 
-            while (!token.IsCancellationRequested)
+            try
             {
-                int read = await client.ReceiveAsync(bufferSegment, SocketFlags.None);
+                while (!token.IsCancellationRequested)
+                {
+                    int read = await client.ReceiveAsync(bufferSegment, SocketFlags.None).WithCancellation(token);
 
-                var payloadSegment = new ArraySegment<byte>(readBuffer, 0, read);
-                stream.Process(payloadSegment);
+                    var payloadSegment = new ArraySegment<byte>(readBuffer, 0, read);
+                    stream.Process(payloadSegment);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                if (!token.IsCancellationRequested) throw;
             }
         }
 

--- a/RtspClientSharp/Rtsp/RtspHttpTransportClient.cs
+++ b/RtspClientSharp/Rtsp/RtspHttpTransportClient.cs
@@ -22,9 +22,11 @@ namespace RtspClientSharp.Rtsp
         private Stream _dataNetworkStream;
         private uint _commandCounter;
         private EndPoint _remoteEndPoint = new IPEndPoint(IPAddress.None, 0);
+        private EndPoint _localEndPoint = new IPEndPoint(IPAddress.Any, 0);
         private int _disposed;
 
         public override EndPoint RemoteEndPoint => _remoteEndPoint;
+        public override EndPoint LocalEndPoint => _localEndPoint;
 
         public RtspHttpTransportClient(ConnectionParameters connectionParameters)
             : base(connectionParameters)
@@ -45,6 +47,7 @@ namespace RtspClientSharp.Rtsp
             await _streamDataClient.ConnectAsync(connectionUri.Host, httpPort);
 
             _remoteEndPoint = _streamDataClient.RemoteEndPoint;
+            _localEndPoint = _streamDataClient.LocalEndPoint;
             _dataNetworkStream = new NetworkStream(_streamDataClient, false);
 
             string request = ComposeGetRequest();

--- a/RtspClientSharp/Rtsp/RtspRequestMessageFactory.cs
+++ b/RtspClientSharp/Rtsp/RtspRequestMessageFactory.cs
@@ -54,6 +54,16 @@ namespace RtspClientSharp.Rtsp
             return rtspRequestMessage;
         }
 
+        public RtspRequestMessage CreateSetupUdpMulticastRequest(string trackName)
+        {
+            Uri trackUri = GetTrackUri(trackName);
+
+            var rtspRequestMessage = new RtspRequestMessage(RtspMethod.SETUP, trackUri, ProtocolVersion,
+                NextCSeqProvider, _userAgent, SessionId);
+            rtspRequestMessage.Headers.Add("Transport", $"RTP/AVP;multicast");
+            return rtspRequestMessage;
+        }
+
         public RtspRequestMessage CreatePlayRequest()
         {
             Uri uri = GetContentBasedUri();

--- a/RtspClientSharp/Rtsp/RtspTcpTransportClient.cs
+++ b/RtspClientSharp/Rtsp/RtspTcpTransportClient.cs
@@ -14,9 +14,11 @@ namespace RtspClientSharp.Rtsp
         private Socket _tcpClient;
         private Stream _networkStream;
         private EndPoint _remoteEndPoint = new IPEndPoint(IPAddress.None, 0);
+        private EndPoint _localEndPoint = new IPEndPoint(IPAddress.Any, 0);
         private int _disposed;
 
         public override EndPoint RemoteEndPoint => _remoteEndPoint;
+        public override EndPoint LocalEndPoint => _localEndPoint;
 
         public RtspTcpTransportClient(ConnectionParameters connectionParameters)
             : base(connectionParameters)
@@ -34,6 +36,7 @@ namespace RtspClientSharp.Rtsp
             await _tcpClient.ConnectAsync(connectionUri.Host, rtspPort);
 
             _remoteEndPoint = _tcpClient.RemoteEndPoint;
+            _localEndPoint = _tcpClient.LocalEndPoint;
             _networkStream = new NetworkStream(_tcpClient, false);
         }
 

--- a/RtspClientSharp/Rtsp/RtspTransportClient.cs
+++ b/RtspClientSharp/Rtsp/RtspTransportClient.cs
@@ -17,6 +17,7 @@ namespace RtspClientSharp.Rtsp
         private Authenticator _authenticator;
 
         public abstract EndPoint RemoteEndPoint { get; }
+        public abstract EndPoint LocalEndPoint { get; }
 
         protected RtspTransportClient(ConnectionParameters connectionParameters)
         {

--- a/RtspClientSharp/Utils/NetworkClientFactory.cs
+++ b/RtspClientSharp/Utils/NetworkClientFactory.cs
@@ -5,7 +5,7 @@ namespace RtspClientSharp.Utils
     static class NetworkClientFactory
     {
         private const int TcpReceiveBufferDefaultSize = 64 * 1024;
-        private const int UdpReceiveBufferDefaultSize = 128 * 1024;
+        private const int UdpReceiveBufferDefaultSize = 512 * 1024;
         private const int SIO_UDP_CONNRESET = -1744830452;
         private static readonly byte[] EmptyOptionInValue = { 0, 0, 0, 0 };
 

--- a/RtspClientSharp/Utils/SocketExtensions.cs
+++ b/RtspClientSharp/Utils/SocketExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Net;
+using System.Net.Sockets;
+
+namespace RtspClientSharp.Utils
+{
+    static class SocketExtensions
+    {
+        public static void JoinMulticastGroup(this Socket socket, IPAddress multicastGroupIp, IPAddress localIp)
+        {
+            MulticastOption multicastOption = new MulticastOption(multicastGroupIp, localIp);
+            socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, multicastOption);
+        }
+
+        public static void LeaveMulticastGroup(this Socket socket, IPAddress multicastGroupIp)
+        {
+            MulticastOption multicastOption = new MulticastOption(multicastGroupIp);
+            socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.DropMembership, multicastOption);
+        }
+
+        public static void JoinMulticastSourceGroup(this Socket socket, IPAddress multicastGroupIp, IPAddress localIp, IPAddress sourceIp)
+        {
+            byte[] membershipAddresses = new byte[12]; // 3 IPs * 4 bytes (IPv4)
+            Buffer.BlockCopy(multicastGroupIp.GetAddressBytes(), 0, membershipAddresses, 0, 4);
+            Buffer.BlockCopy(sourceIp.GetAddressBytes(), 0, membershipAddresses, 4, 4);
+            Buffer.BlockCopy(localIp.GetAddressBytes(), 0, membershipAddresses, 8, 4);
+            socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddSourceMembership, membershipAddresses);
+        }
+    }
+}

--- a/RtspClientSharp/Utils/SocketExtensions.cs
+++ b/RtspClientSharp/Utils/SocketExtensions.cs
@@ -9,22 +9,78 @@ namespace RtspClientSharp.Utils
         public static void JoinMulticastGroup(this Socket socket, IPAddress multicastGroupIp, IPAddress localIp)
         {
             MulticastOption multicastOption = new MulticastOption(multicastGroupIp, localIp);
-            socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, multicastOption);
+            if (multicastGroupIp.AddressFamily == AddressFamily.InterNetwork)
+                socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, multicastOption);
+            else if (multicastGroupIp.AddressFamily == AddressFamily.InterNetworkV6)
+                socket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.AddMembership, multicastOption);
         }
 
         public static void LeaveMulticastGroup(this Socket socket, IPAddress multicastGroupIp)
         {
             MulticastOption multicastOption = new MulticastOption(multicastGroupIp);
-            socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.DropMembership, multicastOption);
+            if (multicastGroupIp.AddressFamily == AddressFamily.InterNetwork)
+                socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.DropMembership, multicastOption);
+            else if (multicastGroupIp.AddressFamily == AddressFamily.InterNetworkV6)
+                socket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.DropMembership, multicastOption);
         }
 
         public static void JoinMulticastSourceGroup(this Socket socket, IPAddress multicastGroupIp, IPAddress localIp, IPAddress sourceIp)
         {
-            byte[] membershipAddresses = new byte[12]; // 3 IPs * 4 bytes (IPv4)
-            Buffer.BlockCopy(multicastGroupIp.GetAddressBytes(), 0, membershipAddresses, 0, 4);
-            Buffer.BlockCopy(sourceIp.GetAddressBytes(), 0, membershipAddresses, 4, 4);
-            Buffer.BlockCopy(localIp.GetAddressBytes(), 0, membershipAddresses, 8, 4);
-            socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddSourceMembership, membershipAddresses);
+            // let's try to convert all IPs to type provided by server in "destination" parameter
+            if (multicastGroupIp.AddressFamily == AddressFamily.InterNetwork)
+            {
+                if (localIp.AddressFamily != AddressFamily.InterNetwork)
+                {
+                    if (localIp.IsIPv4MappedToIPv6)
+                        localIp = localIp.MapToIPv4();
+                    else
+                        localIp = IPAddress.Any;
+                }
+                if (sourceIp.AddressFamily != AddressFamily.InterNetwork)
+                {
+                    if (sourceIp.IsIPv4MappedToIPv6)
+                        sourceIp = sourceIp.MapToIPv4();
+                    else
+                        sourceIp = IPAddress.None;
+                }
+                if (!IPAddress.None.Equals(sourceIp))
+                {
+                    byte[] membershipAddresses = new byte[12]; // 3 IPs * 4 bytes (IPv4)
+                    Buffer.BlockCopy(multicastGroupIp.GetAddressBytes(), 0, membershipAddresses, 0, 4);
+                    Buffer.BlockCopy(sourceIp.GetAddressBytes(), 0, membershipAddresses, 4, 4);
+                    Buffer.BlockCopy(localIp.GetAddressBytes(), 0, membershipAddresses, 8, 4);
+                    socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddSourceMembership, membershipAddresses);
+                }
+                else
+                {
+                    // if we don't have good source IP, join group without source
+                    JoinMulticastGroup(socket, multicastGroupIp, localIp);
+                }
+            }
+            else if (multicastGroupIp.AddressFamily == AddressFamily.InterNetworkV6)
+            {
+                if (localIp.AddressFamily != AddressFamily.InterNetworkV6)
+                {
+                    localIp = localIp.MapToIPv6();
+                }
+                if (sourceIp.AddressFamily != AddressFamily.InterNetworkV6)
+                {
+                    sourceIp = sourceIp.MapToIPv6();
+                }
+                if (!IPAddress.None.Equals(sourceIp))
+                {
+                    byte[] membershipAddresses = new byte[48]; // 3 IPs * 16 bytes (IPv6)
+                    Buffer.BlockCopy(multicastGroupIp.GetAddressBytes(), 0, membershipAddresses, 0, 16);
+                    Buffer.BlockCopy(sourceIp.GetAddressBytes(), 0, membershipAddresses, 16, 16);
+                    Buffer.BlockCopy(localIp.GetAddressBytes(), 0, membershipAddresses, 32, 16);
+                    socket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.AddSourceMembership, membershipAddresses);
+                }
+                else
+                {
+                    // if we don't have good source IP, join group without source
+                    JoinMulticastGroup(socket, multicastGroupIp, localIp);
+                }
+            }
         }
     }
 }

--- a/RtspClientSharp/Utils/TaskExtensions.cs
+++ b/RtspClientSharp/Utils/TaskExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace RtspClientSharp.Utils
@@ -16,6 +18,20 @@ namespace RtspClientSharp.Utils
         private static void HandleException(Task task)
         {
             var ignore = task.Exception;
+        }
+
+        public static async Task<T> WithCancellation<T>(this Task<T> task, CancellationToken cancellationToken)
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            using (cancellationToken.Register(s => ((TaskCompletionSource<bool>)s).TrySetResult(true), tcs))
+            {
+                if (task != await Task.WhenAny(task, tcs.Task))
+                {
+                    throw new OperationCanceledException(cancellationToken);
+                }
+            }
+
+            return task.Result;
         }
     }
 }


### PR DESCRIPTION
bug fixes:
1) SDES packet header - padding flag must be "false". 
Fixed.
2) SDES chunk - text length should not include /0. 
Fixed.
3) SDES reports were sent to RTP port instead of RTCP. 
Fixed.
4) Since Socket.ReceiveAsync do not natively support cancellation, and receive task was waiting for complete of both RTP and RTCP receive, "normal" cancellation never took place. CloseRtspSessionAsync never called because sockets were closed due to CancelTimeout. As a result, TEARDOWN was never sent.
I added WithCancellation task extension and now ReadAsync can be canceled immediately without wait for next incoming packet. I modified only UDP part, but extension can be used in other places too.

improvements:
1) "Receiver Report Goodbye" packet is sent on session close.
2) UDP sockets are bound to only one interface, which IP is retrieved from already connected RTSP session. This improves security in certain usage scenarios, especially with multicast.

new features:
1) UDP multicast support. New SETUP request asking for multicast. New socket extension for multicast groups.
Implementation logic is similar to FFMPEG "forced multicast" or VLC --rtsp-mcast option.

todo:
1) so far tested on only one device - TRUEN HD encoder
2) Transport Protocol may be selected based on device capabilities (AUTO option?)
