### PR TITLE
SIO_UDP_CONNRESET: prevent exception throwing on unsupported platforms

### DIFF
--- a/RtspClientSharp/Utils/NetworkClientFactory.cs
+++ b/RtspClientSharp/Utils/NetworkClientFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Sockets;
+﻿using System;
+using System.Net.Sockets;
 
 namespace RtspClientSharp.Utils
 {
@@ -27,7 +28,16 @@ namespace RtspClientSharp.Utils
                 ReceiveBufferSize = UdpReceiveBufferDefaultSize,
                 DualMode = true
             };
-            socket.IOControl((IOControlCode)SIO_UDP_CONNRESET, EmptyOptionInValue, null);
+
+            try
+            {
+                socket.IOControl((IOControlCode)SIO_UDP_CONNRESET, EmptyOptionInValue, null);
+            }
+            catch (PlatformNotSupportedException)
+            {
+                
+            }
+            
             return socket;
         }
     }


### PR DESCRIPTION
`SIO_UDP_CONNRESET` code doesn't work under Linux. I tried to find out why, and came to the conclusion that this is Windows-specific thing.