### PR TITLE
fixed IndexOfBytes bug

### DIFF
--- a/RtspClientSharp.UnitTests/Utils/ArrayUtilsTests.cs
+++ b/RtspClientSharp.UnitTests/Utils/ArrayUtilsTests.cs
@@ -96,6 +96,17 @@ namespace RtspClientSharp.UnitTests.Utils
         }
 
         [TestMethod]
+        public void IndexOfBytes_PatternExists_BackTrack_ReturnsActualIndex()
+        {
+            var pattern = new byte[] { 0, 0, 1 };
+            var bytes = new byte[] { 0, 5, 0, 0, 0, 1, 3, 4 };
+
+            int index = ArrayUtils.IndexOfBytes(bytes, pattern, 1, bytes.Length - 1);
+
+            Assert.AreEqual(3, index);
+        }
+
+        [TestMethod]
         public void IndexOfBytes_PatternNotExists_ReturnsMinusOne()
         {
             var pattern = new byte[] {1, 2, 3};

--- a/RtspClientSharp/Utils/ArrayUtils.cs
+++ b/RtspClientSharp/Utils/ArrayUtils.cs
@@ -57,7 +57,14 @@
             for (; startIndex < endIndex; startIndex++)
             {
                 if (array[startIndex] != pattern[foundIndex])
+                {
+                    // When the pattern is partially found but then mismatches, the start search index
+                    // must be moved back to index just after where the original successful matching started.
+                    // Otherwise, matches that begin within an attempted match would be missed.
+                    // e.g., array: 123400001567, pattern: 0001, would errnoneously return -1
+                    startIndex -= foundIndex; // for loop will then add 1
                     foundIndex = 0;
+                }
                 else if (++foundIndex == patternLength)
                     return startIndex - foundIndex + 1;
             }


### PR DESCRIPTION
ArrayUtils IndexOfBytes needs to move its startIndex back if a partially successful match ends up mismatching. Otherwise a match that starts within this attempted match will be missed.
I noticed this happen in H264Slicer.Slice. It missed a second nal unit start marker (0001) because the bytes contained 00001 which matched the start marker up to 000 and correctly gave up the match when the next 0 didn't match the needed 1. But then it continued without moving the start index back, so missed the 0001 match and returned -1.
My video still played regardless. The nal unit type was type 8 and I'm not sure what that impacts.
I added a test case to cover this.